### PR TITLE
Add basics index.yml

### DIFF
--- a/basics/delegates.md
+++ b/basics/delegates.md
@@ -1,0 +1,4 @@
+Delegates
+=========
+
+To be filled

--- a/basics/index.yml
+++ b/basics/index.yml
@@ -6,3 +6,17 @@ ordering:
 - storage-classes
 - controlling-flow
 - functions
+#- structs
+#- arrays
+#- slices
+#- alias-strings
+#- loops
+#- foreach
+#- ranges
+#- associative-arrays
+#- classes
+#- interfaces
+#- templates
+- delegates
+#- exceptions
+#- further-reading

--- a/index.yml
+++ b/index.yml
@@ -3,3 +3,4 @@ start: welcome/welcome-to-d
 repo: dlang-tour/japanese
 ordering:
 - welcome
+- basics


### PR DESCRIPTION
(should add the existing basics pages to the tour)

Currently reachable at http://tour.dlang.org