### PR TITLE
Remove explicit dependency on mir-algorithm + bump lubeck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+dist: trusty
 language: d
 d:
   - dmd
@@ -6,9 +6,11 @@ d:
 branches:
   only:
     - master
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libevent-dev libblas-dev liblapack-dev
+addons:
+  apt:
+    packages:
+    - libevent-dev
+    - libopenblas-dev
 script:
   - git clone https://github.com/stonemaster/dlang-tour ../tour
   - mkdir -p ../tour/public/content/lang

--- a/dub/lubeck.md
+++ b/dub/lubeck.md
@@ -18,8 +18,7 @@ LinuxやWindowsでは、バックエンドとして [OpenBLAS](http://www.openbl
 
 ```d
 /+dub.sdl:
-dependency "lubeck" version="~>0.0"
-dependency "mir-algorithm" version="~>0.7"
+dependency "lubeck" version="~>0.1"
 libs "lapack" "blas"
 
 +/

--- a/dub/lubeck.md
+++ b/dub/lubeck.md
@@ -19,8 +19,6 @@ LinuxやWindowsでは、バックエンドとして [OpenBLAS](http://www.openbl
 ```d
 /+dub.sdl:
 dependency "lubeck" version="~>0.1"
-libs "lapack" "blas"
-
 +/
 import std.stdio;
 import mir.ndslice: magic, repeat, as, slice;


### PR DESCRIPTION
Required due to a version conflict.

See also: https://github.com/dlang-tour/english/pull/265